### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,19 +2,19 @@
   "name": "grunt-w3c-markup-validation",
   "version": "0.0.1",
   "description": "Grunt task for W3C validation of markup ",
-  "dependencies" : {
-    "w3cjs" : "0.1.24",
-    "underscore" : "1.6.0"
+  "dependencies": {
+    "w3cjs": "0.1.24",
+    "underscore": "1.6.0"
   },
-  "devDependencies" : {
-    "mocha" : "*",
-    "chai" : "*",
-    "rewire" : "*", 
+  "devDependencies": {
+    "mocha": "*",
+    "chai": "*",
+    "rewire": "*",
     "grunt-cli": "*",
-    "grunt-contrib-jshint" : "*",
-    "grunt-mocha-test" : "*",
-    "grunt-git" : "*",
-    "grunt-shell" : "*"
+    "grunt-contrib-jshint": "*",
+    "grunt-mocha-test": "*",
+    "grunt-git": "*",
+    "grunt-shell": "*"
   },
   "scripts": {
     "test": "./node_modules/grunt-cli/bin/grunt test"
@@ -24,23 +24,26 @@
     "url": "git://github.com/code-computerlove/grunt-w3c-markup-validation.git"
   },
   "keywords": [
-    "gruntplugin", "w3c"
+    "gruntplugin",
+    "w3c"
   ],
   "engines": {
     "node": ">= 0.8.0"
   },
   "author": "code computerlove",
-  "contributors" : [{
-    "name": "Iain Mitchell",
-    "email": "iainjmitchell@gmail.com"
-  }],
+  "contributors": [
+    {
+      "name": "Iain Mitchell",
+      "email": "iainjmitchell@gmail.com"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/code-computerlove/grunt-w3c-markup-validation/issues"
   },
   "homepage": "https://github.com/code-computerlove/grunt-w3c-markup-validation",
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": ">=0.4.0"
   },
   "files": [
     "tasks",


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
